### PR TITLE
Add StackStorm workflow for provision volume

### DIFF
--- a/contrib/st2/opensds/actions/attach_volume.py
+++ b/contrib/st2/opensds/actions/attach_volume.py
@@ -44,8 +44,3 @@ class AttachVolumeAction(Action):
 
         r = requests.post(url=url, data=json.dumps(data), headers=headers)
         r.raise_for_status()
-
-
-if __name__ == '__main__':
-
-    AttachVolumeAction()

--- a/contrib/st2/opensds/actions/attach_volume.py
+++ b/contrib/st2/opensds/actions/attach_volume.py
@@ -1,0 +1,19 @@
+import requests
+import json
+
+from st2common.runners.base_action import Action
+
+
+class AttachVolumeAction(Action):
+
+    def run(self, url="", vol=""):
+        data = {"VolumeId": vol}
+        headers = {'content-type': 'application/json'}
+        r = requests.post(url=url, data=json.dumps(data), headers=headers)
+        print(r.status_code)
+        print(r.text)
+
+
+if __name__ == '__main__':
+
+    AttachVolumeAction()

--- a/contrib/st2/opensds/actions/attach_volume.py
+++ b/contrib/st2/opensds/actions/attach_volume.py
@@ -43,9 +43,7 @@ class AttachVolumeAction(Action):
             projectid + "/block/attachments"
 
         r = requests.post(url=url, data=json.dumps(data), headers=headers)
-        print(r.status_code)
         r.raise_for_status()
-        print(r.text)
 
 
 if __name__ == '__main__':

--- a/contrib/st2/opensds/actions/attach_volume.py
+++ b/contrib/st2/opensds/actions/attach_volume.py
@@ -1,3 +1,17 @@
+# Copyright 2019 The OpenSDS Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import requests
 import json
 
@@ -5,12 +19,32 @@ from st2common.runners.base_action import Action
 
 
 class AttachVolumeAction(Action):
-
-    def run(self, url="", vol=""):
-        data = {"VolumeId": vol}
+    def run(self,
+            ipaddr="",
+            port="",
+            projectid="",
+            mountpoint="",
+            hostinfo="",
+            connectioninfo="",
+            tenantid="",
+            accessprotocol="",
+            volumeid=""):
+        data = {
+            "Mountpoint": mountpoint,
+            "HostInfo": hostinfo,
+            "ConnectionInfo": connectioninfo,
+            "TenantId": tenantid,
+            "AccessProtocol": accessprotocol,
+            "VolumeId": volumeid}
         headers = {'content-type': 'application/json'}
+        url = "http://" + \
+            ipaddr + ":" + \
+            port + "/v1beta/" + \
+            projectid + "/block/attachments"
+
         r = requests.post(url=url, data=json.dumps(data), headers=headers)
         print(r.status_code)
+        r.raise_for_status()
         print(r.text)
 
 

--- a/contrib/st2/opensds/actions/attach_volume.yaml
+++ b/contrib/st2/opensds/actions/attach_volume.yaml
@@ -1,0 +1,13 @@
+---
+description: Attach Volume
+enabled: true
+entry_point: attach_volume.py
+name: attach-volume
+parameters:
+  url:
+    type: string
+    required: true
+  vol:
+    type: string
+    required: true
+runner_type: "python-script"

--- a/contrib/st2/opensds/actions/attach_volume.yaml
+++ b/contrib/st2/opensds/actions/attach_volume.yaml
@@ -4,10 +4,31 @@ enabled: true
 entry_point: attach_volume.py
 name: attach-volume
 parameters:
-  url:
+  ipaddr:
     type: string
     required: true
-  vol:
+  port:
     type: string
     required: true
+  projectid:
+    type: string
+    required: true
+  volumeid:
+    type: string
+    required: true
+  mountpoint:
+    type: string
+    required: false
+  hostinfo:
+    type: object
+    required: false
+  connectioninfo:
+    type: object
+    required: false
+  tenantid:
+    type: string
+    required: false
+  accessprotocol:
+    type: string
+    required: false
 runner_type: "python-script"

--- a/contrib/st2/opensds/actions/create_volume.py
+++ b/contrib/st2/opensds/actions/create_volume.py
@@ -46,9 +46,7 @@ class CreateVolumeAction(Action):
 
         headers = {'content-type': 'application/json'}
         r = requests.post(url=url, data=json.dumps(data), headers=headers)
-        print(r.status_code)
         r.raise_for_status()
-        print(r.text)
         resp = r.json()
         return resp["id"]
 

--- a/contrib/st2/opensds/actions/create_volume.py
+++ b/contrib/st2/opensds/actions/create_volume.py
@@ -1,0 +1,26 @@
+import requests
+import json
+
+from st2common.runners.base_action import Action
+
+
+class CreateVolumeAction(Action):
+
+    def run(self, url="", name="", size=1):
+        data = {
+            "Name": name,
+            "Description": "Test Volume from StackStorm",
+            "Size": size
+            }
+        headers = {'content-type': 'application/json'}
+        r = requests.post(url=url, data=json.dumps(data), headers=headers)
+        print(r.status_code)
+        print(r.text)
+        resp = r.json()
+        return resp["id"]
+
+
+if __name__ == '__main__':
+
+    volumeId = CreateVolumeAction()
+    print('%s : %s' % 'Volume created with Id', volumeId)

--- a/contrib/st2/opensds/actions/create_volume.py
+++ b/contrib/st2/opensds/actions/create_volume.py
@@ -1,3 +1,17 @@
+# Copyright 2019 The OpenSDS Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import requests
 import json
 
@@ -5,16 +19,35 @@ from st2common.runners.base_action import Action
 
 
 class CreateVolumeAction(Action):
-
-    def run(self, url="", name="", size=1):
+    def run(self,
+            ipaddr="",
+            port="",
+            projectid="",
+            name="",
+            description="Volume",
+            availabilityzone="default",
+            profileid="",
+            snapshotid="",
+            snapshotfromcloud="",
+            size=1):
         data = {
             "Name": name,
-            "Description": "Test Volume from StackStorm",
+            "Description": description,
+            "AvailabilityZone": availabilityzone,
+            "ProfileId": profileid,
+            "SnapshotId": snapshotid,
+            "SnapshotFromCloud": snapshotfromcloud,
             "Size": size
             }
+        url = "http://" + \
+            ipaddr + ":" + \
+            port + "/v1beta/" + \
+            projectid + "/block/volumes"
+
         headers = {'content-type': 'application/json'}
         r = requests.post(url=url, data=json.dumps(data), headers=headers)
         print(r.status_code)
+        r.raise_for_status()
         print(r.text)
         resp = r.json()
         return resp["id"]
@@ -23,4 +56,4 @@ class CreateVolumeAction(Action):
 if __name__ == '__main__':
 
     volumeId = CreateVolumeAction()
-    print('%s : %s' % 'Volume created with Id', volumeId)
+    print('%s : %s' % ('Volume created with Id', volumeId))

--- a/contrib/st2/opensds/actions/create_volume.py
+++ b/contrib/st2/opensds/actions/create_volume.py
@@ -49,9 +49,3 @@ class CreateVolumeAction(Action):
         r.raise_for_status()
         resp = r.json()
         return resp["id"]
-
-
-if __name__ == '__main__':
-
-    volumeId = CreateVolumeAction()
-    print('%s : %s' % ('Volume created with Id', volumeId))

--- a/contrib/st2/opensds/actions/create_volume.yaml
+++ b/contrib/st2/opensds/actions/create_volume.yaml
@@ -1,0 +1,16 @@
+---
+description: Create Volume
+enabled: true
+entry_point: create_volume.py
+name: create-volume
+parameters:
+  url:
+    type: string
+    required: true
+  name:
+    type: string
+    required: true
+  size:
+    type: integer
+    required: true
+runner_type: "python-script"

--- a/contrib/st2/opensds/actions/create_volume.yaml
+++ b/contrib/st2/opensds/actions/create_volume.yaml
@@ -4,13 +4,34 @@ enabled: true
 entry_point: create_volume.py
 name: create-volume
 parameters:
-  url:
+  ipaddr:
+    type: string
+    required: true
+  port:
+    type: string
+    required: true
+  projectid:
     type: string
     required: true
   name:
     type: string
     required: true
+  description:
+    type: string
+    required: false
+  availabilityzone:
+    type: string
+    required: false
   size:
     type: integer
     required: true
+  profileid:
+    type: string
+    required: false
+  snapshotid:
+    type: string
+    required: false
+  snapshotfromcloud:
+    type: string
+    required: false
 runner_type: "python-script"

--- a/contrib/st2/opensds/actions/delete_attachment.py
+++ b/contrib/st2/opensds/actions/delete_attachment.py
@@ -1,0 +1,19 @@
+import requests
+
+from st2common.runners.base_action import Action
+
+
+class DeleteAttachmentAction(Action):
+    def run(self, ip="", port="", projectid="", attachmentid=""):
+        url = "http://" + \
+            ip + ":" + \
+            port + "/v1beta/" + \
+            projectid + "/block/attachments/" + \
+            attachmentid
+        r = requests.delete(url=url)
+        print(r.status_code)
+        r.raise_for_status()
+
+
+if __name__ == '__main__':
+    DeleteAttachmentAction()

--- a/contrib/st2/opensds/actions/delete_attachment.py
+++ b/contrib/st2/opensds/actions/delete_attachment.py
@@ -26,7 +26,3 @@ class DeleteAttachmentAction(Action):
             attachmentid
         r = requests.delete(url=url)
         r.raise_for_status()
-
-
-if __name__ == '__main__':
-    DeleteAttachmentAction()

--- a/contrib/st2/opensds/actions/delete_attachment.py
+++ b/contrib/st2/opensds/actions/delete_attachment.py
@@ -1,12 +1,26 @@
+# Copyright 2019 The OpenSDS Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import requests
 
 from st2common.runners.base_action import Action
 
 
 class DeleteAttachmentAction(Action):
-    def run(self, ip="", port="", projectid="", attachmentid=""):
+    def run(self, ipaddr="", port="", projectid="", attachmentid=""):
         url = "http://" + \
-            ip + ":" + \
+            ipaddr + ":" + \
             port + "/v1beta/" + \
             projectid + "/block/attachments/" + \
             attachmentid

--- a/contrib/st2/opensds/actions/delete_attachment.py
+++ b/contrib/st2/opensds/actions/delete_attachment.py
@@ -25,7 +25,6 @@ class DeleteAttachmentAction(Action):
             projectid + "/block/attachments/" + \
             attachmentid
         r = requests.delete(url=url)
-        print(r.status_code)
         r.raise_for_status()
 
 

--- a/contrib/st2/opensds/actions/delete_attachment.yaml
+++ b/contrib/st2/opensds/actions/delete_attachment.yaml
@@ -4,7 +4,7 @@ enabled: true
 entry_point: delete_attachment.py
 name: delete-attachment
 parameters:
-  ip:
+  ipaddr:
     required: true
     type: string
   port:

--- a/contrib/st2/opensds/actions/delete_attachment.yaml
+++ b/contrib/st2/opensds/actions/delete_attachment.yaml
@@ -1,0 +1,19 @@
+---
+description: Delete Attachment
+enabled: true
+entry_point: delete_attachment.py
+name: delete-attachment
+parameters:
+  ip:
+    required: true
+    type: string
+  port:
+    required: true
+    type: string
+  projectid:
+    type: string
+    required: true
+  attachmentid:
+    type: string
+    required: true
+runner_type: "python-script"

--- a/contrib/st2/opensds/actions/delete_volume.py
+++ b/contrib/st2/opensds/actions/delete_volume.py
@@ -26,7 +26,3 @@ class DeleteVolumeAction(Action):
             volumeid
         r = requests.delete(url=url)
         r.raise_for_status()
-
-
-if __name__ == '__main__':
-    DeleteVolumeAction()

--- a/contrib/st2/opensds/actions/delete_volume.py
+++ b/contrib/st2/opensds/actions/delete_volume.py
@@ -1,0 +1,19 @@
+import requests
+
+from st2common.runners.base_action import Action
+
+
+class DeleteVolumeAction(Action):
+    def run(self, ip="", port="", projectid="", volumeid=""):
+        url = "http://" + \
+            ip + ":" + \
+            port + "/v1beta/" + \
+            projectid + "/block/volumes/" + \
+            volumeid
+        r = requests.delete(url=url)
+        print(r.status_code)
+        r.raise_for_status()
+
+
+if __name__ == '__main__':
+    DeleteVolumeAction()

--- a/contrib/st2/opensds/actions/delete_volume.py
+++ b/contrib/st2/opensds/actions/delete_volume.py
@@ -25,7 +25,6 @@ class DeleteVolumeAction(Action):
             projectid + "/block/volumes/" + \
             volumeid
         r = requests.delete(url=url)
-        print(r.status_code)
         r.raise_for_status()
 
 

--- a/contrib/st2/opensds/actions/delete_volume.py
+++ b/contrib/st2/opensds/actions/delete_volume.py
@@ -1,12 +1,26 @@
+# Copyright 2019 The OpenSDS Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import requests
 
 from st2common.runners.base_action import Action
 
 
 class DeleteVolumeAction(Action):
-    def run(self, ip="", port="", projectid="", volumeid=""):
+    def run(self, ipaddr="", port="", projectid="", volumeid=""):
         url = "http://" + \
-            ip + ":" + \
+            ipaddr + ":" + \
             port + "/v1beta/" + \
             projectid + "/block/volumes/" + \
             volumeid

--- a/contrib/st2/opensds/actions/delete_volume.yaml
+++ b/contrib/st2/opensds/actions/delete_volume.yaml
@@ -1,0 +1,19 @@
+---
+description: Delete Volume
+enabled: true
+entry_point: delete_volume.py
+name: delete-volume
+parameters:
+  ip:
+    required: true
+    type: string
+  port:
+    required: true
+    type: string
+  projectid:
+    type: string
+    required: true
+  volumeid:
+    type: string
+    required: true
+runner_type: "python-script"

--- a/contrib/st2/opensds/actions/delete_volume.yaml
+++ b/contrib/st2/opensds/actions/delete_volume.yaml
@@ -4,7 +4,7 @@ enabled: true
 entry_point: delete_volume.py
 name: delete-volume
 parameters:
-  ip:
+  ipaddr:
     required: true
     type: string
   port:

--- a/contrib/st2/opensds/actions/list_volume.py
+++ b/contrib/st2/opensds/actions/list_volume.py
@@ -21,9 +21,7 @@ class ListVolumeAction(Action):
     def run(self, ipaddr="", port="", projectid=""):
         url = "http://"+ipaddr+":"+port+"/v1beta/"+projectid+"/block/volumes"
         r = requests.get(url=url)
-        print(r.status_code)
         r.raise_for_status()
-        print(r.text)
 
 
 if __name__ == '__main__':

--- a/contrib/st2/opensds/actions/list_volume.py
+++ b/contrib/st2/opensds/actions/list_volume.py
@@ -1,11 +1,25 @@
+# Copyright 2019 The OpenSDS Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import requests
 
 from st2common.runners.base_action import Action
 
 
 class ListVolumeAction(Action):
-    def run(self, ip="", port="", projectid=""):
-        url = "http://"+ip+":"+port+"/v1beta/"+projectid+"/block/volumes"
+    def run(self, ipaddr="", port="", projectid=""):
+        url = "http://"+ipaddr+":"+port+"/v1beta/"+projectid+"/block/volumes"
         r = requests.get(url=url)
         print(r.status_code)
         r.raise_for_status()

--- a/contrib/st2/opensds/actions/list_volume.py
+++ b/contrib/st2/opensds/actions/list_volume.py
@@ -22,7 +22,3 @@ class ListVolumeAction(Action):
         url = "http://"+ipaddr+":"+port+"/v1beta/"+projectid+"/block/volumes"
         r = requests.get(url=url)
         r.raise_for_status()
-
-
-if __name__ == '__main__':
-    ListVolumeAction()

--- a/contrib/st2/opensds/actions/list_volume.py
+++ b/contrib/st2/opensds/actions/list_volume.py
@@ -1,0 +1,16 @@
+import requests
+
+from st2common.runners.base_action import Action
+
+
+class ListVolumeAction(Action):
+    def run(self, ip="", port="", projectid=""):
+        url = "http://"+ip+":"+port+"/v1beta/"+projectid+"/block/volumes"
+        r = requests.get(url=url)
+        print(r.status_code)
+        r.raise_for_status()
+        print(r.text)
+
+
+if __name__ == '__main__':
+    ListVolumeAction()

--- a/contrib/st2/opensds/actions/list_volume.yaml
+++ b/contrib/st2/opensds/actions/list_volume.yaml
@@ -1,0 +1,16 @@
+---
+description: List Volume
+enabled: true
+entry_point: list_volume.py
+name: list-volume
+parameters:
+  ip:
+    required: true
+    type: string
+  port:
+    required: true
+    type: string
+  projectid:
+    type: string
+    required: true
+runner_type: "python-script"

--- a/contrib/st2/opensds/actions/list_volume.yaml
+++ b/contrib/st2/opensds/actions/list_volume.yaml
@@ -4,7 +4,7 @@ enabled: true
 entry_point: list_volume.py
 name: list-volume
 parameters:
-  ip:
+  ipaddr:
     required: true
     type: string
   port:

--- a/contrib/st2/opensds/actions/provision_volume.yaml
+++ b/contrib/st2/opensds/actions/provision_volume.yaml
@@ -1,0 +1,26 @@
+---
+description: Provision an OpenSDS Volume
+enabled: true
+runner_type: mistral-v2
+entry_point: workflows/provision_volume.yaml
+name: provision-volume
+pack: opensds
+parameters:
+  ip:
+    required: true
+    type: string
+  port:
+    required: true
+    type: string
+  pid:
+    required: true
+    type: string
+  name:
+    required: true
+    type: string
+  size:
+    required: true
+    type: integer
+  timeout:
+    type: integer
+    default: 60

--- a/contrib/st2/opensds/actions/provision_volume.yaml
+++ b/contrib/st2/opensds/actions/provision_volume.yaml
@@ -6,21 +6,51 @@ entry_point: workflows/provision_volume.yaml
 name: provision-volume
 pack: opensds
 parameters:
-  ip:
+  ipaddr:
     required: true
     type: string
   port:
     required: true
     type: string
-  pid:
+  projectid:
     required: true
     type: string
   name:
     required: true
     type: string
+  description:
+    type: string
+    required: false
+  availabilityzone:
+    type: string
+    required: false
   size:
-    required: true
     type: integer
+    required: true
+  profileid:
+    type: string
+    required: false
+  snapshotid:
+    type: string
+    required: false
+  snapshotfromcloud:
+    type: string
+    required: false
+  mountpoint:
+    type: string
+    required: false
+  hostinfo:
+    type: object
+    required: false
+  connectioninfo:
+    type: object
+    required: false
+  tenantid:
+    type: string
+    required: false
+  accessprotocol:
+    type: string
+    required: false
   timeout:
     type: integer
     default: 60

--- a/contrib/st2/opensds/actions/workflows/provision_volume.yaml
+++ b/contrib/st2/opensds/actions/workflows/provision_volume.yaml
@@ -1,0 +1,37 @@
+version: "2.0"
+name: "opensds.provision-volume"
+
+workflows:
+
+    main:
+        type: direct
+        input:
+            - ip
+            - port
+            - pid
+            - name
+            - size
+            - timeout
+        output:
+            tagline: "<% $.print_status %>"
+        task-defaults:
+          on-error:
+            - fail
+        tasks:
+            create_volume:
+                action: opensds.create-volume
+                input:
+                    url: "http://<% $.ip %>:<% $.port %>/v1beta/<% $.pid %>/block/volumes"
+                    name: "<% $.name %>"
+                    size: '<% $.size %>'
+                publish:
+                   volid: <% task(create_volume).result.result %>
+                on-success:
+                    - attach_volume
+            attach_volume:
+                action: opensds.attach-volume
+                input:
+                    url: "http://<% $.ip %>:<% $.port %>/v1beta/<% $.pid %>/block/attachments"
+                    vol: <% $.volid %>
+                publish:
+                    print_status : <% task(attach_volume).result.stdout %>

--- a/contrib/st2/opensds/actions/workflows/provision_volume.yaml
+++ b/contrib/st2/opensds/actions/workflows/provision_volume.yaml
@@ -6,11 +6,21 @@ workflows:
     main:
         type: direct
         input:
-            - ip
+            - ipaddr
             - port
-            - pid
+            - projectid
             - name
+            - description
+            - availabilityzone
             - size
+            - profileid
+            - snapshotid
+            - snapshotfromcloud
+            - mountpoint
+            - hostinfo
+            - connectioninfo
+            - tenantid
+            - accessprotocol
             - timeout
         output:
             tagline: "<% $.print_status %>"
@@ -21,17 +31,31 @@ workflows:
             create_volume:
                 action: opensds.create-volume
                 input:
-                    url: "http://<% $.ip %>:<% $.port %>/v1beta/<% $.pid %>/block/volumes"
+                    ipaddr: "<% $.ipaddr %>"
+                    port: "<% $.port %>"
+                    projectid: "<% $.projectid %>"
                     name: "<% $.name %>"
+                    description: "<% $.description %>"
+                    availabilityzone: "<% $.availabilityzone %>"
                     size: '<% $.size %>'
+                    profileid: "<% $.profileid %>"
+                    snapshotid: "<% $.snapshotid %>"
+                    snapshotfromcloud: '<% $.snapshotfromcloud %>'
                 publish:
-                   volid: <% task(create_volume).result.result %>
+                   volumeid: <% task(create_volume).result.result %>
                 on-success:
                     - attach_volume
             attach_volume:
                 action: opensds.attach-volume
                 input:
-                    url: "http://<% $.ip %>:<% $.port %>/v1beta/<% $.pid %>/block/attachments"
-                    vol: <% $.volid %>
+                    ipaddr: "<% $.ipaddr %>"
+                    port: "<% $.port %>"
+                    projectid: "<% $.projectid %>"
+                    volumeid: <% $.volumeid %>
+                    mountpoint: <% $.mountpoint %>
+                    hostinfo: <% $.hostinfo %>
+                    connectioninfo: <% $.connectioninfo %>
+                    tenantid: <% $.tenantid %>
+                    accessprotocol: <% $.accessprotocol %>
                 publish:
                     print_status : <% task(attach_volume).result.stdout %>


### PR DESCRIPTION
This will add a StackStorm workflow to Provision Volume using OpenSDS. StackStorm actions for 'create, delete, attach and list' volumes are also added to support this workflow.