### PR TITLE
Add logging configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,14 @@
 language: python
+sudo: required
 
 python:
   - "2.7"
   - "3.5"
+
+before_install:
+  - sudo mkdir -p /var/log/opensds
+  - sudo touch /var/log/opensds/orchestration.log
+  - sudo chmod 666 /var/log/opensds/orchestration.log
 
 install:
   - pip install tox codecov

--- a/orchestration/server.py
+++ b/orchestration/server.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import logging
 from flask import Flask
 from orchestration.api.services import service
 from orchestration.utils import config
@@ -25,7 +25,9 @@ class ServerManager:
         self._init_server()
 
     def _init_logging(self):
-        pass
+        logging.basicConfig(level=config.LOGGING_LEVEL,
+                            format=config.LOGGIGN_FORMAT,
+                            filename=config.LOGGING_FILE)
 
     def _init_server(self):
         self.app.url_map.strict_slashes = False

--- a/orchestration/utils/config.py
+++ b/orchestration/utils/config.py
@@ -19,7 +19,7 @@ PORT = "5000"
 
 # logging configuration
 LOGGING_FILE = "/var/log/opensds/orchestration.log"
-LOGGIGN_FORMAT = "format = [%(asctime)s] [%(levelname)s] [%(name)s] " \
+LOGGIGN_FORMAT = "[%(asctime)s] [%(levelname)s] [%(name)s] " \
     "[%(funcName)s():%(lineno)s] [PID:%(process)d TID:%(thread)d] %(message)s"
 LOGGING_LEVEL = "INFO"
 


### PR DESCRIPTION
This pr will add logging configuration to this repo, I use `logging` as a logging library, the logging format looks like: 
```
[2019-04-29 14:50:38,640] [INFO] [werkzeug] [_log():122] [PID:11949 TID:140098502100736]  * Running on http://127.0.0.1:5000/ (Press CTRL+C to quit)
[2019-04-29 14:50:56,359] [INFO] [root] [get_service():25] [PID:11949 TID:140098448336640] get_service started...
[2019-04-29 14:50:56,361] [INFO] [werkzeug] [_log():122] [PID:11949 TID:140098448336640] 127.0.0.1 - - [29/Apr/2019 14:50:56] "GET /v1/orchestration/services/67b0d6a0-dfa1-4662-a08f-6dc33fd77546 HTTP/1.1" 200 -

```