### PR TITLE
Upgrade reqeusts version from vulnerable version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ sqlalchemy
 st2client
 uuid
 cryptography
-requests<=2.15
+requests>=2.20.0
 ConfigParser


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The Requests package before 2.20.0 for Python sends an HTTP Authorization header to an http URI upon receiving a same-hostname https-to-http redirect, which makes it easier for remote attackers to discover credentials by sniffing the network. 

This PR will solve this, see detail at: https://nvd.nist.gov/vuln/detail/CVE-2018-18074



**Which issue this PR fixes**: fixes vulnerable requests version.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
