### PR TITLE
Fix the issue of instance creation failure

### DIFF
--- a/orchestration/api/instances.py
+++ b/orchestration/api/instances.py
@@ -133,7 +133,6 @@ def instance_ops(tenant_id=''):
     service_map['created_at'] = service_obj['created_at']
     service_map['updated_at'] = service_obj['updated_at']
     service_map['input'] = ret_json['parameters']
-    del service_map['input']['auth_token']
 
     wf_hash = {}
     wf_hash['id'] = ret_json['id']


### PR DESCRIPTION
…values. The auth_token should not be sent in the response. It should be removed from the dict. Instance creation was failing because it was trying to delete same auth_token key twice. Fixed the same.

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: Instance creation fails with KeyError for auth_token.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #77 

**Special notes for your reviewer**: @himanshuvar @wisererik 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
