### PR TITLE
Adding unique constraint on the service name

### DIFF
--- a/orchestration/api/instances.py
+++ b/orchestration/api/instances.py
@@ -145,7 +145,12 @@ def instance_ops(tenant_id=''):
     service_map['user_id'] = user_id
     service_map['tenant_id'] = tenant_id
     service_map['status'] = status_map[ret_json['status']]
-    service_obj = create_service(None, service_map)
+    try:
+        service_obj = create_service(None, service_map)
+    except Exception as ex:
+        err_msg = str(ex)
+        logger.error("received exception in creating service: %s", err_msg)
+        return jsonify(err_msg), 400
 
     # Now that service is created append appropriate values
     service_map['service_id'] = sd_id

--- a/orchestration/db/api.py
+++ b/orchestration/db/api.py
@@ -21,6 +21,7 @@ from contextlib import contextmanager
 from orchestration.db import Session
 from orchestration.db import models
 from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.sql.expression import and_
 from orchestration.utils.config import logger
 
@@ -135,10 +136,18 @@ def create_service(context, values):
     for key, value in values.items():
         if hasattr(service, key):
             setattr(service, key, value)
-
-    with session_scope() as session:
-        session.add(service)
-    return get_service(None, values['id'])
+    try:
+        with session_scope() as session:
+            session.add(service)
+        return get_service(None, values['id'])
+    except IntegrityError as ie:
+        session.rollback()
+        err_msg = str(ie)
+        if err_msg.find('services.name'):
+            err_msg = "Instance Name should be unique"
+            raise ValueError(err_msg)
+    except SQLAlchemyError as sqe:
+        raise ValueError(str(sqe))
 
 
 def get_service(context, id):

--- a/orchestration/db/models.py
+++ b/orchestration/db/models.py
@@ -17,7 +17,7 @@ SQLAlchemy models for orchestration.
 import datetime
 import uuid
 
-from sqlalchemy import ForeignKey
+from sqlalchemy import ForeignKey, UniqueConstraint
 from sqlalchemy import Column, String, Text, DateTime
 from sqlalchemy.orm import relationship
 from sqlalchemy.inspection import inspect
@@ -103,6 +103,7 @@ class Service(ModelBase):
                                       primaryjoin='Service. \
                                       service_definition_id == \
                                       ServiceDefinition.id')
+    __table_args__ = (UniqueConstraint('name'),)
 
 
 class Workflow(ModelBase):


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: If service is created with an existing name then it should not be allowed. To solve this, we have put a unique constraint on the Service name.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #84

**Special notes for your reviewer**: Tested from UI that when service is created with same name then it throws 400 error and the response is " Instance name should be unique"

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
